### PR TITLE
feat(gates): add SXdg

### DIFF
--- a/2026-05-circuit-simulator/qcsim/README.md
+++ b/2026-05-circuit-simulator/qcsim/README.md
@@ -381,8 +381,10 @@ qc = QuantumCircuit(2, backend="tensor")      # Use tensor backend (faster for 1
 | `qc.y(q)` | Pauli-Y | `i|1⟩` |
 | `qc.z(q)` | Pauli-Z | `|0⟩` (Z only affects `|1⟩`) |
 | `qc.s(q)` | S gate | `|0⟩` (S adds phase to `|1⟩`) |
+| `qc.sdg(q)` | Sdg gate |
 | `qc.t(q)` | T gate | `|0⟩` (T adds π/4 phase to `|1⟩`) |
-| `qc.sx(q)` | √X | Square root of X |
+| `qc.sx(q)` | √X gate | Square root of X |
+| `qc.sxdg(q)` | √X† gate | inverse of SX |
 | `qc.rx(q, θ)` | Rx(θ) | Rotation around X-axis by θ radians |
 | `qc.ry(q, θ)` | Ry(θ) | Rotation around Y-axis by θ radians |
 | `qc.rz(q, θ)` | Rz(θ) | Rotation around Z-axis by θ radians |

--- a/2026-05-circuit-simulator/qcsim/README.md
+++ b/2026-05-circuit-simulator/qcsim/README.md
@@ -381,7 +381,7 @@ qc = QuantumCircuit(2, backend="tensor")      # Use tensor backend (faster for 1
 | `qc.y(q)` | Pauli-Y | `i|1⟩` |
 | `qc.z(q)` | Pauli-Z | `|0⟩` (Z only affects `|1⟩`) |
 | `qc.s(q)` | S gate | `|0⟩` (S adds phase to `|1⟩`) |
-| `qc.sdg(q)` | Sdg gate |
+| `qc.sdg(q)` | Sdg gate | `|0⟩` (Sdg adds phase to `|1⟩`)|
 | `qc.t(q)` | T gate | `|0⟩` (T adds π/4 phase to `|1⟩`) |
 | `qc.sx(q)` | √X gate | Square root of X |
 | `qc.sxdg(q)` | √X† gate | inverse of SX |

--- a/2026-05-circuit-simulator/qcsim/qcsim/analyzer.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/analyzer.py
@@ -17,8 +17,8 @@ if TYPE_CHECKING:
 # Gate categories for classification
 _TWO_QUBIT_GATES = {"CNOT_C", "CNOT", "CX", "CY", "CZ", "SWAP_A", "SWAP", "CP", "CCX"}
 _T_GATES = {"T", "Tdg"}
-_SINGLE_QUBIT_GATES = {"H", "X", "Y", "Z", "S", "Sdg", "SX", "Rx", "Ry", "Rz", "P", "U", "I"}
-_CLIFFORD_GATES = {"H", "X", "Y", "Z", "S", "Sdg", "CNOT", "CNOT_C", "CX", "CZ", "SWAP_A", "SWAP"}
+_SINGLE_QUBIT_GATES = {"H", "X", "Y", "Z", "S", "Sdg", "SX", "SXdg", "Rx", "Ry", "Rz", "P", "U", "I"}
+_CLIFFORD_GATES = {"H", "X", "Y", "Z", "S", "Sdg", "SX", "SXdg", "CNOT", "CNOT_C", "CX", "CZ", "SWAP_A", "SWAP"}
 
 
 @dataclass

--- a/2026-05-circuit-simulator/qcsim/qcsim/circuit.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/circuit.py
@@ -539,6 +539,22 @@ class QuantumCircuit:
         self._log.append(("SX", [qubit], None))
         return self
 
+    def sxdg(self, qubit: int) -> "QuantumCircuit":
+        """Apply the SX-dagger gate (inverse of SX).
+        Args:
+            qubit: Target qubit index.
+
+        Returns:
+            Self, for method chaining.
+
+        Raises:
+            QubitIndexError: If the qubit index is out of range.
+        """
+        self._check(qubit)
+        self._gate_single(G.SXdg(), qubit)
+        self._log.append(("SXdg", [qubit], None))
+        return self
+
     # ------------------------------------------------------------------ #
     #  Parametric single-qubit gates
     # ------------------------------------------------------------------ #
@@ -952,6 +968,7 @@ class QuantumCircuit:
             "T": lambda: self.t(qubits[0]),
             "Tdg": lambda: self.tdg(qubits[0]),
             "SX": lambda: self.sx(qubits[0]),
+            "SXdg": lambda: self.sxdg(qubits[0]),
             "Rx": lambda: self.rx(qubits[0], p["theta"]),
             "Ry": lambda: self.ry(qubits[0], p["theta"]),
             "Rz": lambda: self.rz(qubits[0], p["theta"]),

--- a/2026-05-circuit-simulator/qcsim/qcsim/gates.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/gates.py
@@ -125,6 +125,14 @@ def SX() -> np.ndarray:
     return np.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]], dtype=complex) * 0.5
 
 
+def SXdg() -> np.ndarray:
+    """SX-dagger gate (inverse of SX). SXdg = SX†.
+    Returns:
+        2x2 complex array [[1-1j, 1+1j], [1+1j, 1-1j]] * 0.5.
+    """
+    return np.array([[1 - 1j, 1 + 1j], [1 + 1j, 1 - 1j]], dtype=complex) * 0.5
+
+
 def Rx(theta: float) -> np.ndarray:
     """Rotation around the X-axis by angle theta (radians).
 
@@ -262,5 +270,5 @@ def SWAP_mat() -> np.ndarray:
 #: Maps gate name → factory function (for gates with no parameters).
 SINGLE_QUBIT_GATES: dict[str, object] = {
     "I": I, "H": H, "X": X, "Y": Y, "Z": Z,
-    "S": S, "Sdg": Sdg, "T": T, "Tdg": Tdg, "SX": SX,
+    "S": S, "Sdg": Sdg, "T": T, "Tdg": Tdg, "SX": SX, "SXdg": SXdg,
 }

--- a/2026-05-circuit-simulator/qcsim/qcsim/tui.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/tui.py
@@ -106,7 +106,7 @@ def _input(prompt: str) -> str:
 _GATE_DISPLAY: Dict[str, str] = {
     "H":        "H",
     "X":        "X",
-    "SXdg":     "SXdg",   # SX-dagger gate
+    "SXdg":     "D",   # SX-dagger gate
     "CNOT_C":   "@",   # CNOT control  (@  looks like a control dot)
     "CNOT_T":   "+",   # CNOT target   (+ looks like XOR/circle-plus)
     "SWAP_A":   "~",   # SWAP endpoint A
@@ -295,7 +295,7 @@ def _render_grid(
     lines.append("")
 
     # Help
-    lines.append("  Gates : [H] [X] [SXdg] [C]NOT [W]AP  |  [Backspace] delete  |  [?] gate help")
+    lines.append("  Gates : [H] [X] [D] [C]NOT [W]AP  |  [Backspace] delete  |  [?] gate help")
     lines.append("  Expand: [+] add column  [*] add qubit row")
     lines.append("  Action: [R]un  [E]xport  [I]mport  [Esc] reset  [Q]uit")
     lines.append("  Move  : Arrow keys")
@@ -442,7 +442,7 @@ class CircuitBuilder:
             self._place_single("H")
         elif key == "x":
             self._place_single("X")
-        elif key == "sxdg":
+        elif key == "d":
             self._place_single("SXdg")
 
         # Two-qubit gates
@@ -645,9 +645,9 @@ class CircuitBuilder:
             ),
             "SXdg": (
                 "SX-dagger Gate",
-                "Matrix: [[0.5, -0.5j], [-0.5j, 0.5]]",
-                "SXdg|0> = (|0> - i|1>) / 2",
-                "SXdg|1> = (-i|0> + |1>) / 2",
+                "Matrix: [[0.5-0.5j, 0.5+0.5j], [0.5+0.5j, 0.5-0.5j]]",
+                "SXdg|0> = (0.5-0.5i)|0> + (0.5+0.5i)|1>",
+                "SXdg|1> = (0.5+0.5i)|0> + (0.5-0.5i)|1>",
                 "SXdg*SXdg = X",
                 "",
                 "Use: Inverse of SX gate. Creates opposite phase superposition.",

--- a/2026-05-circuit-simulator/qcsim/qcsim/tui.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/tui.py
@@ -106,6 +106,7 @@ def _input(prompt: str) -> str:
 _GATE_DISPLAY: Dict[str, str] = {
     "H":        "H",
     "X":        "X",
+    "SXdg":     "SXdg",   # SX-dagger gate
     "CNOT_C":   "@",   # CNOT control  (@  looks like a control dot)
     "CNOT_T":   "+",   # CNOT target   (+ looks like XOR/circle-plus)
     "SWAP_A":   "~",   # SWAP endpoint A
@@ -294,7 +295,7 @@ def _render_grid(
     lines.append("")
 
     # Help
-    lines.append("  Gates : [H] [X] [C]NOT [W]AP  |  [Backspace] delete  |  [?] gate help")
+    lines.append("  Gates : [H] [X] [SXdg] [C]NOT [W]AP  |  [Backspace] delete  |  [?] gate help")
     lines.append("  Expand: [+] add column  [*] add qubit row")
     lines.append("  Action: [R]un  [E]xport  [I]mport  [Esc] reset  [Q]uit")
     lines.append("  Move  : Arrow keys")
@@ -441,6 +442,8 @@ class CircuitBuilder:
             self._place_single("H")
         elif key == "x":
             self._place_single("X")
+        elif key == "sxdg":
+            self._place_single("SXdg")
 
         # Two-qubit gates
         elif key == "c":
@@ -591,6 +594,8 @@ class CircuitBuilder:
                     qc.h(row)
                 elif g == "X":
                     qc.x(row)
+                elif g == "SXdg":
+                    qc.sxdg(row)
                 elif g == "CNOT_C":
                     tgt = cell.linked_row
                     if tgt >= 0:
@@ -637,6 +642,15 @@ class CircuitBuilder:
                 "X*X = Identity",
                 "",
                 "Use: Initialise qubits to |1>, flip bits, build CNOT.",
+            ),
+            "SXdg": (
+                "SX-dagger Gate",
+                "Matrix: [[0.5, -0.5j], [-0.5j, 0.5]]",
+                "SXdg|0> = (|0> - i|1>) / 2",
+                "SXdg|1> = (-i|0> + |1>) / 2",
+                "SXdg*SXdg = X",
+                "",
+                "Use: Inverse of SX gate. Creates opposite phase superposition.",
             ),
             "CNOT_C": (
                 "CNOT Gate — Control qubit (@)",

--- a/2026-05-circuit-simulator/qcsim/tests/test_circuit.py
+++ b/2026-05-circuit-simulator/qcsim/tests/test_circuit.py
@@ -169,12 +169,6 @@ class TestRotationGates:
         assert abs(probs.get("0", 0) - 0.5) < 1e-5
         assert abs(probs.get("1", 0) - 0.5) < 1e-5
 
-    def test_sxdg_inverts_sx(self):
-        qc = QuantumCircuit(1)
-        qc.sx(0).sxdg(0)
-        probs = qc.probabilities()
-        assert abs(probs.get("0", 0) - 1.0) < 1e-10
-
     def test_probabilities_sum_one_after_rotation(self):
         qc = QuantumCircuit(3)
         qc.rx(0, 0.3).ry(1, 1.2).rz(2, 2.5)
@@ -297,6 +291,26 @@ class TestCZ:
         qc.cz(0, 1)
         sv = qc.statevector()
         assert abs(sv[0] - 1.0) < 1e-10
+
+class TestSXdg:
+    def test_sxdg_exact_amplitudes_on_zero(self):
+        qc = QuantumCircuit(1)
+        qc.sxdg(0)
+        sv = qc.statevector()
+        assert abs(sv[0] - 0.5 * (1 - 1j)) < 1e-10
+        assert abs(sv[1] - 0.5 * (1 + 1j)) < 1e-10
+
+    def test_sxdg_twice_equals_x(self):
+        qc = QuantumCircuit(1)
+        qc.sxdg(0).sxdg(0)
+        probs = qc.probabilities()
+        assert abs(probs.get("1", 0) - 1.0) < 1e-10
+
+    def test_sxdg_inverts_sx(self):
+        qc = QuantumCircuit(1)
+        qc.sx(0).sxdg(0)
+        probs = qc.probabilities()
+        assert abs(probs.get("0", 0) - 1.0) < 1e-10
 
 
 # ================================================================== #

--- a/2026-05-circuit-simulator/qcsim/tests/test_circuit.py
+++ b/2026-05-circuit-simulator/qcsim/tests/test_circuit.py
@@ -169,6 +169,12 @@ class TestRotationGates:
         assert abs(probs.get("0", 0) - 0.5) < 1e-5
         assert abs(probs.get("1", 0) - 0.5) < 1e-5
 
+    def test_sxdg_inverts_sx(self):
+        qc = QuantumCircuit(1)
+        qc.sx(0).sxdg(0)
+        probs = qc.probabilities()
+        assert abs(probs.get("0", 0) - 1.0) < 1e-10
+
     def test_probabilities_sum_one_after_rotation(self):
         qc = QuantumCircuit(3)
         qc.rx(0, 0.3).ry(1, 1.2).rz(2, 2.5)


### PR DESCRIPTION
## What does this PR do?

<!-- One sentence summary -->

## Type of change

- [ ] 🐛 Bug fix (challenge files, README, tests)
- [ ] ✨ New gate (adds gate to qcsim)
- [ ] 📚 New circuit (adds circuit to circuit-library)
- [ ] 📝 Documentation improvement
- [ ] 🔧 CI / tooling

---

## For new gates (`feat(gates): ...`)

- [ ] Gate matrix is unitary (`U†U = I`) — verified with check in `docs/adding-gates.md`
- [ ] Gate added to `qcsim/gates.py` with docstring
- [ ] Circuit method added to `qcsim/circuit.py`
- [ ] TUI key binding added to `qcsim/tui.py`
- [ ] Gate help text added (`?` overlay)
- [ ] Tests added to `tests/test_circuit.py` (minimum 3 tests)
- [ ] Gate is not a duplicate of existing gate matrix
- [ ] All 52 existing tests still pass: `pytest tests/ -v`

## For new circuits (`feat(library): ...`)

- [ ] Built and tested in the TUI (`qcsim-interactive`)
- [ ] Exported and submitted via `add_circuit.py` (no manual index edits)
- [ ] Description, category, difficulty, tags filled in
- [ ] Circuit runs correctly (press R in TUI to verify output)

## For bug fixes / docs

- [ ] Change is minimal and targeted
- [ ] No solution code added to main repo (solutions go in Discussions)
- [ ] Tested locally

---

## Notes for reviewer

<!-- Anything the reviewer should know -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SXdg gate added to the circuit builder with keyboard shortcut [D], visual display, and integrated help text.

* **Documentation**
  * Python API reference updated to document sdg and sxdg single-qubit gates with consistent formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->