### PR TITLE
feat(circuit library): add 4 qubit GHZ state circuit

### DIFF
--- a/2026-05-circuit-simulator/circuit-library/ghz_4-2.json
+++ b/2026-05-circuit-simulator/circuit-library/ghz_4-2.json
@@ -1,0 +1,63 @@
+{
+  "name": "ghz_4",
+  "num_qubits": 4,
+  "num_cols": 4,
+  "backend": "kronecker",
+  "gates": [
+    {
+      "gate": "H",
+      "row": 0,
+      "col": 0
+    },
+    {
+      "gate": "CNOT_C",
+      "row": 0,
+      "col": 1,
+      "linked_row": 1
+    },
+    {
+      "gate": "CNOT_T",
+      "row": 1,
+      "col": 1,
+      "linked_row": 0
+    },
+    {
+      "gate": "CNOT_C",
+      "row": 1,
+      "col": 2,
+      "linked_row": 2
+    },
+    {
+      "gate": "CNOT_T",
+      "row": 2,
+      "col": 2,
+      "linked_row": 1
+    },
+    {
+      "gate": "CNOT_C",
+      "row": 2,
+      "col": 3,
+      "linked_row": 3
+    },
+    {
+      "gate": "CNOT_T",
+      "row": 3,
+      "col": 3,
+      "linked_row": 2
+    }
+  ],
+  "fingerprint": "53ac5ae9913daae9",
+  "description": "It implements a 4 qubit GHZ (Greenberger-Horne-Zeilinger) state using hadamard and cnot gates.",
+  "category": "entanglement",
+  "difficulty": "beginner",
+  "tags": [
+    "beginner",
+    "entanglement",
+    "ghz"
+  ],
+  "source_url": "Nature, QuEra Computing",
+  "created_at": "2026-06-05",
+  "version": "1.0",
+  "num_gates": 4,
+  "verified": false
+}

--- a/2026-05-circuit-simulator/circuit-library/ghz_4-2.json
+++ b/2026-05-circuit-simulator/circuit-library/ghz_4-2.json
@@ -55,9 +55,9 @@
     "entanglement",
     "ghz"
   ],
-  "source_url": "Nature, QuEra Computing",
+  "source_url": "",
   "created_at": "2026-06-05",
   "version": "1.0",
-  "num_gates": 4,
+  "num_gates": 7,
   "verified": false
 }

--- a/2026-05-circuit-simulator/circuit-library/index.json
+++ b/2026-05-circuit-simulator/circuit-library/index.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Auto-maintained index. Do not edit manually — use add_circuit.py.",
+  "_comment": "Auto-maintained index. Do not edit manually \u2014 use add_circuit.py.",
   "circuits": [
     {
       "file": "examples/bell-state.json",
@@ -8,7 +8,12 @@
       "num_gates": 2,
       "category": "entanglement",
       "difficulty": "beginner",
-      "tags": ["entanglement", "beginner", "fundamental", "bell"],
+      "tags": [
+        "entanglement",
+        "beginner",
+        "fundamental",
+        "bell"
+      ],
       "fingerprint": "a1b2c3d4e5f6a7b8",
       "author": "Quantum Collective",
       "created_at": "2026-05-31",
@@ -22,12 +27,35 @@
       "num_gates": 3,
       "category": "entanglement",
       "difficulty": "beginner",
-      "tags": ["entanglement", "beginner", "ghz", "fundamental"],
+      "tags": [
+        "entanglement",
+        "beginner",
+        "ghz",
+        "fundamental"
+      ],
       "fingerprint": "b2c3d4e5f6a7b8c9",
       "author": "Quantum Collective",
       "created_at": "2026-05-31",
       "version": "1.0",
       "verified": true
+    },
+    {
+      "file": "ghz_4-2.json",
+      "name": "ghz_4",
+      "num_qubits": 4,
+      "num_gates": 4,
+      "category": "entanglement",
+      "difficulty": "beginner",
+      "tags": [
+        "beginner",
+        "entanglement",
+        "ghz"
+      ],
+      "fingerprint": "53ac5ae9913daae9",
+      "author": "unknown",
+      "created_at": "2026-06-05",
+      "version": "1.0",
+      "verified": false
     }
   ]
 }

--- a/2026-05-circuit-simulator/circuit-library/index.json
+++ b/2026-05-circuit-simulator/circuit-library/index.json
@@ -43,7 +43,7 @@
       "file": "ghz_4-2.json",
       "name": "ghz_4",
       "num_qubits": 4,
-      "num_gates": 4,
+      "num_gates": 7,
       "category": "entanglement",
       "difficulty": "beginner",
       "tags": [
@@ -52,7 +52,7 @@
         "ghz"
       ],
       "fingerprint": "53ac5ae9913daae9",
-      "author": "unknown",
+      "author": "QuantumImperator",
       "created_at": "2026-06-05",
       "version": "1.0",
       "verified": false


### PR DESCRIPTION
## What does this PR do?

Adds a 4-qubit Greenberger-Horne-Zeilinger (GHZ) state to the circuit library to demonstrate multi-qubit entanglement.

## Type of change

- [ ] 🐛 Bug fix (challenge files, README, tests)
- [ ] ✨ New gate (adds gate to qcsim)
- [ ] 📚 New circuit (adds circuit to circuit-library)
- [ ] 📝 Documentation improvement
- [ ] 🔧 CI / tooling

---

## For new gates (`feat(gates): ...`)

- [ ] Gate matrix is unitary (`U†U = I`) — verified with check in `docs/adding-gates.md`
- [ ] Gate added to `qcsim/gates.py` with docstring
- [ ] Circuit method added to `qcsim/circuit.py`
- [ ] TUI key binding added to `qcsim/tui.py`
- [ ] Gate help text added (`?` overlay)
- [ ] Tests added to `tests/test_circuit.py` (minimum 3 tests)
- [ ] Gate is not a duplicate of existing gate matrix
- [ ] All 52 existing tests still pass: `pytest tests/ -v`

## For new circuits (`feat(library): ...`)

- [x] Built and tested in the TUI (`qcsim-interactive`)
- [x] Exported and submitted via `add_circuit.py` 
- [x] Description, category, difficulty, tags filled in.
- [x] Circuit runs correctly (press R in TUI to verify output)

## For bug fixes / docs

- [ ] Change is minimal and targeted
- [ ] No solution code added to main repo (solutions go in Discussions)
- [ ] Tested locally

---

## Notes for reviewer

Built natively in TUI using a Hadamard gate on the first qubit followed by  CNOTs (targets on the bottom). Verified the state vector output correctly splits 50/50 between `|0000>` and `|1111>`. The fingerprint and index was successfully generated via the `add_circuit.py` script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a 4-qubit GHZ state circuit to the circuit library for simulation and experimentation.

* **Documentation**
  * Updated the circuit library index and metadata so the new circuit and its tags appear correctly in the library listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->