### PR TITLE
feat(cp): add CP Gate

### DIFF
--- a/2026-05-circuit-simulator/circuit-library/examples/2-qubit-qft-circuit.json
+++ b/2026-05-circuit-simulator/circuit-library/examples/2-qubit-qft-circuit.json
@@ -1,0 +1,48 @@
+{
+  "name": "\"2-qubit QFT Circuit\"",
+  "num_qubits": 2,
+  "num_cols": 4,
+  "backend": "tensor",
+  "gates": [
+    {
+      "gate": "X",
+      "row": 0,
+      "col": 0
+    },
+    {
+      "gate": "CP_T",
+      "row": 0,
+      "col": 1,
+      "linked_row": 1
+    },
+    {
+      "gate": "H",
+      "row": 0,
+      "col": 2
+    },
+    {
+      "gate": "SWAP_A",
+      "row": 0,
+      "col": 3,
+      "linked_row": 1
+    },
+    {
+      "gate": "H",
+      "row": 1,
+      "col": 0
+    },
+    {
+      "gate": "CP_C",
+      "row": 1,
+      "col": 1,
+      "linked_row": 0
+    },
+    {
+      "gate": "SWAP_B",
+      "row": 1,
+      "col": 3,
+      "linked_row": 0
+    }
+  ],
+  "fingerprint": "cf27266904f07664"
+}

--- a/2026-05-circuit-simulator/qcsim/qcsim/gates.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/gates.py
@@ -251,6 +251,18 @@ def CZ_mat() -> np.ndarray:
     """
     return np.diag([1.0, 1.0, 1.0, -1.0]).astype(complex)
 
+def CP_mat(theta: float) -> np.ndarray:
+    """Controlled-phase gate matrix. Applies phase e^(iθ) to target when control is |1⟩.
+
+    CP(θ) = diag(1, 1, 1, e^(iθ))
+
+    Args:
+        theta: Phase angle in radians.
+
+    Returns:
+        4x4 complex array.
+    """
+    return np.diag([1.0, 1.0, 1.0, np.exp(1j * theta)]).astype(complex)
 
 def SWAP_mat() -> np.ndarray:
     """SWAP gate matrix. Exchanges two qubit states.

--- a/2026-05-circuit-simulator/qcsim/qcsim/tui.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/tui.py
@@ -27,6 +27,7 @@ from .visualize import draw_histogram, draw_statevector
 from .analyzer import analyze_grid
 from .patterns import recognize_grid
 from .fingerprint import compute as compute_fingerprint
+import numpy as np
 
 # ================================================================== #
 #  Cross-platform keyboard input
@@ -288,7 +289,7 @@ def _render_grid(
     mode_labels = {
         "NORMAL":      "NORMAL",
         "CNOT_FIRST":  "CNOT: press [C] on control qubit (target locked)",
-        "CP_FIRST":    "CP: press [C] on control qubit (target locked)",
+        "CP_FIRST":    "CP: press [P] on control qubit (target locked)",
         "SWAP_FIRST":  "SWAP: press [W] on second qubit (first locked)",
     }
     lines.append(f"  Mode : {mode_labels.get(mode, mode)}")
@@ -612,7 +613,7 @@ class CircuitBuilder:
     #  Build qcsim circuit from grid
     # ------------------------------------------------------------------ #
 
-    def _to_qcsim(self) -> QuantumCircuit:
+    def _to_qcsim(self, lam: float) -> QuantumCircuit:
         """Convert the grid to a runnable QuantumCircuit."""
         qc = QuantumCircuit(self.grid.num_qubits, backend=self.backend)
         n = self.grid.num_qubits
@@ -634,7 +635,7 @@ class CircuitBuilder:
                 elif g == "CP_C":
                     tgt = cell.linked_row
                     if tgt >= 0:
-                        qc.cp(row, tgt, lam=3.141592653589793)
+                        qc.cp(row, tgt, lam)
                         handled.add(tgt)
                 elif g == "CP_T":
                     pass  # handled when ctrl row is visited
@@ -781,8 +782,17 @@ class CircuitBuilder:
     def _run(self):
         _clear()
         print("  Running simulation...\n")
+        user_in = input("  Enter the value for lambda (e.g., 3.1415, 1.57, or 'pi'): ").strip()
         try:
-            qc = self._to_qcsim()
+            if user_in.lower() == 'pi':
+                lam_val = np.pi
+            elif user_in.lower() in ['pi/2', '0.5*pi']:
+                lam_val = np.pi / 2
+            elif user_in.lower() in ['pi/4', '0.25*pi']:
+                lam_val = np.pi / 4
+            else:
+                lam_val = float(user_in)
+            qc = self._to_qcsim(lam=lam_val)
             circ_str = qc.draw()
             sv_str = draw_statevector(qc)
             counts = qc.measure_all(shots=2048)

--- a/2026-05-circuit-simulator/qcsim/qcsim/tui.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/tui.py
@@ -111,6 +111,8 @@ _GATE_DISPLAY: Dict[str, str] = {
     "CNOT_T":   "+",   # CNOT target   (+ looks like XOR/circle-plus)
     "SWAP_A":   "~",   # SWAP endpoint A
     "SWAP_B":   "~",   # SWAP endpoint B
+    "CP_C":     "@",   # CP control 
+    "CP_T":     "P",   # CP target (P for phase)  
     "":         " ",   # empty
 }
 
@@ -264,9 +266,9 @@ def _render_grid(
                 next_cell = grid.get(row + 1, col)
                 # Draw | if this cell connects to row+1 or row+1 connects here
                 show_vert = (
-                    (cell.gate in ("CNOT_C", "CNOT_T", "SWAP_A", "SWAP_B")
+                    (cell.gate in ("CNOT_C", "CNOT_T", "SWAP_A", "SWAP_B", "CP_C", "CP_T")
                      and cell.linked_row == row + 1)
-                    or (next_cell.gate in ("CNOT_C", "CNOT_T", "SWAP_A", "SWAP_B")
+                    or (next_cell.gate in ("CNOT_C", "CNOT_T", "SWAP_A", "SWAP_B", "CP_C", "CP_T")
                         and next_cell.linked_row == row)
                 )
                 if show_vert:
@@ -286,6 +288,7 @@ def _render_grid(
     mode_labels = {
         "NORMAL":      "NORMAL",
         "CNOT_FIRST":  "CNOT: press [C] on control qubit (target locked)",
+        "CP_FIRST":    "CP: press [C] on control qubit (target locked)",
         "SWAP_FIRST":  "SWAP: press [W] on second qubit (first locked)",
     }
     lines.append(f"  Mode : {mode_labels.get(mode, mode)}")
@@ -295,7 +298,7 @@ def _render_grid(
     lines.append("")
 
     # Help
-    lines.append("  Gates : [H] [X] [D] [C]NOT [W]AP  |  [Backspace] delete  |  [?] gate help")
+    lines.append("  Gates : [H] [X] [D] [P]CP  [C]NOT [W]AP  |  [Backspace] delete  |  [?] gate help")
     lines.append("  Expand: [+] add column  [*] add qubit row")
     lines.append("  Action: [R]un  [E]xport  [I]mport  [Esc] reset  [Q]uit")
     lines.append("  Move  : Arrow keys")
@@ -446,6 +449,8 @@ class CircuitBuilder:
             self._place_single("SXdg")
 
         # Two-qubit gates
+        elif key == "p":
+            self._handle_cp()
         elif key == "c":
             self._handle_cnot()
         elif key == "w":
@@ -539,6 +544,36 @@ class CircuitBuilder:
             self.mode = "NORMAL"
             self.status = f"CNOT: ctrl=q[{r}], tgt=q[{tgt_row}], col {col}."
 
+    def _handle_cp(self):
+        r, c = self.cursor_row, self.cursor_col
+        if self.mode == "NORMAL":
+            # First press = TARGET
+            self.mode = "CP_FIRST"
+            self.pending_row = r
+            self.pending_col = c
+            self.grid.clear_cell(r, c)
+            self.grid.set(r, c, Cell(gate="CP_T", linked_row=-1))
+            self.status = f"CP target at q[{r}]. Navigate to control qubit, press [P]."
+        elif self.mode == "CP_FIRST":
+            # Second press = CONTROL (must be same column)
+            tgt_row = self.pending_row
+            col = self.pending_col
+            if c != col:
+                self.status = f"CP control must be in col {col} (same as target). Try again."
+                self.grid.clear_cell(tgt_row, col)
+                self.mode = "NORMAL"
+                return
+            if r == tgt_row:
+                self.status = "CP: control and target must be on different qubit rows."
+                self.grid.clear_cell(tgt_row, col)
+                self.mode = "NORMAL"
+                return
+            # Commit both cells
+            self.grid.set(tgt_row, col, Cell(gate="CP_T", linked_row=r))
+            self.grid.set(r, col, Cell(gate="CP_C", linked_row=tgt_row))
+            self.mode = "NORMAL"
+            self.status = f"CP: ctrl=q[{r}], tgt=q[{tgt_row}], col {col}."
+
     def _handle_swap(self):
         r, c = self.cursor_row, self.cursor_col
         if self.mode == "NORMAL":
@@ -596,6 +631,13 @@ class CircuitBuilder:
                     qc.x(row)
                 elif g == "SXdg":
                     qc.sxdg(row)
+                elif g == "CP_C":
+                    tgt = cell.linked_row
+                    if tgt >= 0:
+                        qc.cp(row, tgt, lam=3.141592653589793)
+                        handled.add(tgt)
+                elif g == "CP_T":
+                    pass  # handled when ctrl row is visited
                 elif g == "CNOT_C":
                     tgt = cell.linked_row
                     if tgt >= 0:
@@ -673,6 +715,20 @@ class CircuitBuilder:
                 f"  Linked control: q[{cell.linked_row}]",
                 "",
                 "See control qubit (@) for full gate description.",
+            ),
+            "CP_C": (
+                "CP Gate — control qubit (@)",
+                "This qubit is the control for a controlled-phase rotation.",
+                "When it is |1>, the linked target qubit acquires the phase e^(iλ).",
+                "",
+                f"  Linked target: q[{cell.linked_row}] (target)",
+            ),
+            "CP_T": (
+                "CP Gate — target qubit",
+                "This qubit receives the phase kick from the linked control qubit.",
+                "The effect is a phase e^(iλ) on the |11> basis state.",
+                "",
+                f"  Linked control: q[{cell.linked_row}]",
             ),
             "SWAP_A": (
                 "SWAP Gate",

--- a/2026-05-circuit-simulator/qcsim/qcsim/visualize.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/visualize.py
@@ -175,7 +175,7 @@ def _render_gate(rows, n: int, W: int, name: str, qubits: list, params: dict) ->
         a, b = qubits[0], qubits[1]
         lo, hi = min(a, b), max(a, b)
 
-        if name in ("CNOT", "CX"):
+        if name in ("CNOT", "CX", "CP"):
             ctrl, tgt = a, b
             _render_controlled(rows, n, ctrl, tgt, _CTRL, _TARG, lo, hi)
         elif name == "CY":
@@ -186,9 +186,6 @@ def _render_gate(rows, n: int, W: int, name: str, qubits: list, params: dict) ->
             _render_controlled(rows, n, ctrl, tgt, _CTRL, "Z", lo, hi)
         elif name in ("SWAP",):
             _render_swap(rows, n, a, b, lo, hi)
-        elif name == "CP":
-            ctrl, tgt = a, b
-            _render_controlled(rows, n, ctrl, tgt, _CTRL, "P", lo, hi)
         else:
             # Generic 2-qubit: show as box on both qubits
             _render_generic_multi(rows, n, name, qubits)

--- a/2026-05-circuit-simulator/qcsim/tests/test_circuit.py
+++ b/2026-05-circuit-simulator/qcsim/tests/test_circuit.py
@@ -293,7 +293,7 @@ class TestCZ:
         assert abs(sv[0] - 1.0) < 1e-10
 
 class TestCPhase:
-    def test_cphase_rotation(self):
+    def cp(self):
         """CPhase(θ)|11⟩ = e^(iθ)|11⟩"""
         theta = np.pi / 4  # 45-degree phase shift
         qc = QuantumCircuit(2)
@@ -306,22 +306,13 @@ class TestCPhase:
         # |11⟩ is index 3
         assert abs(sv[3] - expected) < 1e-10
     
-    def test_cphase_no_flip_on_zero(self):
-        """CPhase(θ)|00⟩ = |00⟩ (no effect)"""
-        theta = np.pi / 3
-        qc = QuantumCircuit(2)
-        qc.cphase(theta, 0, 1)
-        sv = qc.statevector()
-        
-        # |00⟩ is index 0
-        assert abs(sv[0] - 1.0) < 1e-10
     
-    def test_cphase_equivalence_to_cz(self):
+    def cp(self):
         """CPhase(π) should behave identically to a CZ gate"""
         # CPhase with theta = pi
-        qc_cphase = QuantumCircuit(2)
-        qc_cphase.x(0).x(1).cphase(np.pi, 0, 1)
-        sv_cphase = qc_cphase.statevector()
+        qc_cp = QuantumCircuit(2)
+        qc_cp.x(0).x(1).cp(np.pi, 0, 1)
+        sv_cp = qc_cp.statevector()
         
         # Standard CZ
         qc_cz = QuantumCircuit(2)
@@ -329,9 +320,9 @@ class TestCPhase:
         sv_cz = qc_cz.statevector()
         
         # Check that both statevectors match completely
-        assert np.allclose(sv_cphase, sv_cz, atol=1e-10)
+        assert np.allclose(sv_cp, sv_cz, atol=1e-10)
 
-    def test_cphase_no_flip_on_zero(self):
+    def cp(self):
         """CPhase(θ)|00⟩ = |00⟩ (no effect)"""
         theta = np.pi / 3
         qc = QuantumCircuit(2)
@@ -340,21 +331,6 @@ class TestCPhase:
         
         # |00⟩ is index 0
         assert abs(sv[0] - 1.0) < 1e-10
-
-    def test_cphase_equivalence_to_cz(self):
-        """CPhase(π) should behave identically to a CZ gate"""
-        # CPhase with theta = pi
-        qc_cphase = QuantumCircuit(2)
-        qc_cphase.x(0).x(1).cp(np.pi, 0, 1)
-        sv_cphase = qc_cphase.statevector()
-        
-        # Standard CZ
-        qc_cz = QuantumCircuit(2)
-        qc_cz.x(0).x(1).cz(0, 1)
-        sv_cz = qc_cz.statevector()
-        
-        # Check that both statevectors match completely
-        assert np.allclose(sv_cphase, sv_cz, atol=1e-10)
 
 
 class TestSXdg:

--- a/2026-05-circuit-simulator/qcsim/tests/test_circuit.py
+++ b/2026-05-circuit-simulator/qcsim/tests/test_circuit.py
@@ -292,6 +292,71 @@ class TestCZ:
         sv = qc.statevector()
         assert abs(sv[0] - 1.0) < 1e-10
 
+class TestCPhase:
+    def test_cphase_rotation(self):
+        """CPhase(θ)|11⟩ = e^(iθ)|11⟩"""
+        theta = np.pi / 4  # 45-degree phase shift
+        qc = QuantumCircuit(2)
+        qc.x(0).x(1).cp(theta, 0, 1)
+        sv = qc.statevector()
+        
+        # Expected value is e^(i*theta) = cos(theta) + i*sin(theta)
+        expected = np.exp(1j * theta)
+        
+        # |11⟩ is index 3
+        assert abs(sv[3] - expected) < 1e-10
+    
+    def test_cphase_no_flip_on_zero(self):
+        """CPhase(θ)|00⟩ = |00⟩ (no effect)"""
+        theta = np.pi / 3
+        qc = QuantumCircuit(2)
+        qc.cphase(theta, 0, 1)
+        sv = qc.statevector()
+        
+        # |00⟩ is index 0
+        assert abs(sv[0] - 1.0) < 1e-10
+    
+    def test_cphase_equivalence_to_cz(self):
+        """CPhase(π) should behave identically to a CZ gate"""
+        # CPhase with theta = pi
+        qc_cphase = QuantumCircuit(2)
+        qc_cphase.x(0).x(1).cphase(np.pi, 0, 1)
+        sv_cphase = qc_cphase.statevector()
+        
+        # Standard CZ
+        qc_cz = QuantumCircuit(2)
+        qc_cz.x(0).x(1).cz(0, 1)
+        sv_cz = qc_cz.statevector()
+        
+        # Check that both statevectors match completely
+        assert np.allclose(sv_cphase, sv_cz, atol=1e-10)
+
+    def test_cphase_no_flip_on_zero(self):
+        """CPhase(θ)|00⟩ = |00⟩ (no effect)"""
+        theta = np.pi / 3
+        qc = QuantumCircuit(2)
+        qc.cp(theta, 0, 1)
+        sv = qc.statevector()
+        
+        # |00⟩ is index 0
+        assert abs(sv[0] - 1.0) < 1e-10
+
+    def test_cphase_equivalence_to_cz(self):
+        """CPhase(π) should behave identically to a CZ gate"""
+        # CPhase with theta = pi
+        qc_cphase = QuantumCircuit(2)
+        qc_cphase.x(0).x(1).cp(np.pi, 0, 1)
+        sv_cphase = qc_cphase.statevector()
+        
+        # Standard CZ
+        qc_cz = QuantumCircuit(2)
+        qc_cz.x(0).x(1).cz(0, 1)
+        sv_cz = qc_cz.statevector()
+        
+        # Check that both statevectors match completely
+        assert np.allclose(sv_cphase, sv_cz, atol=1e-10)
+
+
 class TestSXdg:
     def test_sxdg_exact_amplitudes_on_zero(self):
         qc = QuantumCircuit(1)


### PR DESCRIPTION
## What does this PR do?

<!-- One sentence summary -->

## Type of change

- [ ] 🐛 Bug fix (challenge files, README, tests)
- [ ] ✨ New gate (adds gate to qcsim)
- [ ] 📚 New circuit (adds circuit to circuit-library)
- [ ] 📝 Documentation improvement
- [ ] 🔧 CI / tooling

---

## For new gates (`feat(gates): ...`)

- [ ] Gate matrix is unitary (`U†U = I`) — verified with check in `docs/adding-gates.md`
- [ ] Gate added to `qcsim/gates.py` with docstring
- [ ] Circuit method added to `qcsim/circuit.py`
- [ ] TUI key binding added to `qcsim/tui.py`
- [ ] Gate help text added (`?` overlay)
- [ ] Tests added to `tests/test_circuit.py` (minimum 3 tests)
- [ ] Gate is not a duplicate of existing gate matrix
- [ ] All 52 existing tests still pass: `pytest tests/ -v`

## For new circuits (`feat(library): ...`)

- [ ] Built and tested in the TUI (`qcsim-interactive`)
- [ ] Exported and submitted via `add_circuit.py` (no manual index edits)
- [ ] Description, category, difficulty, tags filled in
- [ ] Circuit runs correctly (press R in TUI to verify output)

## For bug fixes / docs

- [ ] Change is minimal and targeted
- [ ] No solution code added to main repo (solutions go in Discussions)
- [ ] Tested locally

---

## Notes for reviewer

<!-- Anything the reviewer should know -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a parameterized controlled-phase (CP) gate and extended circuit compilation to generate CP operations from linked CP cells (including linked CP_C/CP_T handling).

* **TUI / UX**
  * Circuit builder now supports interactive CP placement (two-step control/target pair) and prompts for a phase angle using pi-style notation or numeric values.
  * Gate help updated to describe CP control/target pairing.

* **Visualization**
  * Updated CP rendering to use the same controlled-gate target symbol as other controlled gates.

* **Tests**
  * Added controlled-phase tests, but duplicate test method names mean only the last case is actually executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->