### PR TITLE
Add CY and CP gates

### DIFF
--- a/2026-05-circuit-simulator/qcsim/qcsim/circuit.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/circuit.py
@@ -357,6 +357,47 @@ class QuantumCircuit:
         else:
             self._apply(self._expand_controlled(gate, ctrl, tgt))
 
+    def cy(self,control: int,target: int) -> "QuantumCircuit":
+        """Apply Controlled-Y gate."""
+
+        self._check(control, "control")
+        self._check(target, "target")
+        self._check_distinct(control, target)
+
+        self._gate_controlled(
+            G.Y(),
+            control,
+            target
+        )
+
+        self._log.append(
+            ("CY", [control, target], None)
+        )
+
+        return self
+    def cp(self,control: int,target: int,lam: float) -> "QuantumCircuit":
+        """Apply controlled phase gate."""
+
+        self._check(control, "control")
+        self._check(target, "target")
+        self._check_distinct(control, target)
+
+        self._gate_controlled(
+            G.P(lam),
+            control,
+            target
+        )
+
+        self._log.append(
+            (
+                "CP",
+                [control, target],
+                {"lambda": lam}
+            )
+        )
+
+        return self
+
     def _gate_toffoli(self, c0: int, c1: int, tgt: int) -> None:
         """Dispatch Toffoli to the active backend."""
         if self.backend == "tensor":

--- a/2026-05-circuit-simulator/qcsim/qcsim/circuit.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/circuit.py
@@ -357,46 +357,8 @@ class QuantumCircuit:
         else:
             self._apply(self._expand_controlled(gate, ctrl, tgt))
 
-    def cy(self,control: int,target: int) -> "QuantumCircuit":
-        """Apply Controlled-Y gate."""
-
-        self._check(control, "control")
-        self._check(target, "target")
-        self._check_distinct(control, target)
-
-        self._gate_controlled(
-            G.Y(),
-            control,
-            target
-        )
-
-        self._log.append(
-            ("CY", [control, target], None)
-        )
-
-        return self
-    def cp(self,control: int,target: int,lam: float) -> "QuantumCircuit":
-        """Apply controlled phase gate."""
-
-        self._check(control, "control")
-        self._check(target, "target")
-        self._check_distinct(control, target)
-
-        self._gate_controlled(
-            G.P(lam),
-            control,
-            target
-        )
-
-        self._log.append(
-            (
-                "CP",
-                [control, target],
-                {"lambda": lam}
-            )
-        )
-
-        return self
+    
+    
 
     def _gate_toffoli(self, c0: int, c1: int, tgt: int) -> None:
         """Dispatch Toffoli to the active backend."""

--- a/2026-05-circuit-simulator/qcsim/qcsim/gates.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/gates.py
@@ -293,6 +293,16 @@ def CP_mat(lam: float) -> np.ndarray:
     ).astype(complex)
 
 def CCNOT_mat() -> np.ndarray:
+    """Toffoli (CCNOT) gate matrix.
+
+    Flips the target qubit when both control qubits are |1⟩.
+
+    Basis ordering:
+      |000⟩, |001⟩, |010⟩, |011⟩,
+       |100⟩, |101⟩, |110⟩, |111⟩
+    Returns:
+       8x8 complex array.
+   """
     mat = np.eye(8, dtype=complex)
 
     mat[6, 6] = 0
@@ -334,6 +344,7 @@ def CSWAP_mat() -> np.ndarray:
     mat[6, 5] = 1
 
     return mat
+
 
 # ================================================================== #
 #  Convenience: catalogue of all named single-qubit gates

--- a/2026-05-circuit-simulator/qcsim/qcsim/gates.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/gates.py
@@ -251,6 +251,57 @@ def CZ_mat() -> np.ndarray:
     """
     return np.diag([1.0, 1.0, 1.0, -1.0]).astype(complex)
 
+def CY_mat() -> np.ndarray:
+    """Controlled-Y gate matrix.
+
+    Applies Y to the target qubit when
+    the control qubit is |1>.
+
+    Basis ordering:
+        |00>, |01>, |10>, |11>
+
+    Returns:
+        4x4 complex array.
+    """
+    return np.array(
+        [
+            [1, 0, 0, 0],
+            [0, 1, 0, 0],
+            [0, 0, 0, -1j],
+            [0, 0, 1j, 0],
+        ],
+        dtype=complex,
+    )
+
+def CP_mat(lam: float) -> np.ndarray:
+    """Controlled phase gate.
+
+    Applies a phase e^(i·λ) to |11⟩.
+
+    Basis ordering:
+        |00>, |01>, |10>, |11>
+
+    Args:
+        lam:
+            Phase angle in radians.
+
+    Returns:
+        4x4 complex array.
+    """
+    return np.diag(
+        [1, 1, 1, np.exp(1j * lam)]
+    ).astype(complex)
+
+def CCNOT_mat() -> np.ndarray:
+    mat = np.eye(8, dtype=complex)
+
+    mat[6, 6] = 0
+    mat[7, 7] = 0
+
+    mat[6, 7] = 1
+    mat[7, 6] = 1
+
+    return mat
 
 def SWAP_mat() -> np.ndarray:
     """SWAP gate matrix. Exchanges two qubit states.
@@ -261,7 +312,28 @@ def SWAP_mat() -> np.ndarray:
     return np.array(
         [[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]], dtype=complex
     )
+def CSWAP_mat() -> np.ndarray:
+    """Fredkin (controlled-SWAP) gate.
 
+    Swaps the two target qubits when
+    the control qubit is |1>.
+
+    Basis ordering:
+        |000>, |001>, |010>, |011>,
+        |100>, |101>, |110>, |111>
+
+    Returns:
+        8x8 complex array.
+    """
+    mat = np.eye(8, dtype=complex)
+
+    mat[5, 5] = 0
+    mat[6, 6] = 0
+
+    mat[5, 6] = 1
+    mat[6, 5] = 1
+
+    return mat
 
 # ================================================================== #
 #  Convenience: catalogue of all named single-qubit gates


### PR DESCRIPTION
Adds support for several commonly used controlled quantum gates to qcsim:

Controlled-Y (CY)
Controlled-Phase (CP)
Controlled-SWAP / Fredkin (CSWAP)

This expands the simulator's gate library and improves compatibility with standard quantum circuit implementations found in Qiskit and other frameworks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Controlled-Y (CY) two-qubit gate support
  * Added parameterized Controlled-Phase (CP) gate support
  * Added Toffoli / CCNOT (CCNOT) three-qubit gate support
  * Added Controlled-SWAP (CSWAP) (Fredkin) gate support (replacing the previous basic 4×4 SWAP definition)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->