### PR TITLE
New gates made changes in accordance with https://github.com/LochanPS/Quantum-Collective-Monthly-Projects/pull/5

### DIFF
--- a/2026-05-circuit-simulator/qcsim/qcsim/circuit.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/circuit.py
@@ -357,6 +357,47 @@ class QuantumCircuit:
         else:
             self._apply(self._expand_controlled(gate, ctrl, tgt))
 
+    def cy(self,control: int,target: int) -> "QuantumCircuit":
+        """Apply Controlled-Y gate."""
+
+        self._check(control, "control")
+        self._check(target, "target")
+        self._check_distinct(control, target)
+
+        self._gate_controlled(
+            G.Y(),
+            control,
+            target
+        )
+
+        self._log.append(
+            ("CY", [control, target], None)
+        )
+
+        return self
+    def cp(self,control: int,target: int,lam: float) -> "QuantumCircuit":
+        """Apply controlled phase gate."""
+
+        self._check(control, "control")
+        self._check(target, "target")
+        self._check_distinct(control, target)
+
+        self._gate_controlled(
+            G.P(lam),
+            control,
+            target
+        )
+
+        self._log.append(
+            (
+                "CP",
+                [control, target],
+                {"lambda": lam}
+            )
+        )
+
+        return self
+
     def _gate_toffoli(self, c0: int, c1: int, tgt: int) -> None:
         """Dispatch Toffoli to the active backend."""
         if self.backend == "tensor":

--- a/2026-05-circuit-simulator/qcsim/qcsim/circuit.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/circuit.py
@@ -357,46 +357,8 @@ class QuantumCircuit:
         else:
             self._apply(self._expand_controlled(gate, ctrl, tgt))
 
-    def cy(self,control: int,target: int) -> "QuantumCircuit":
-        """Apply Controlled-Y gate."""
-
-        self._check(control, "control")
-        self._check(target, "target")
-        self._check_distinct(control, target)
-
-        self._gate_controlled(
-            G.Y(),
-            control,
-            target
-        )
-
-        self._log.append(
-            ("CY", [control, target], None)
-        )
-
-        return self
-    def cp(self,control: int,target: int,lam: float) -> "QuantumCircuit":
-        """Apply controlled phase gate."""
-
-        self._check(control, "control")
-        self._check(target, "target")
-        self._check_distinct(control, target)
-
-        self._gate_controlled(
-            G.P(lam),
-            control,
-            target
-        )
-
-        self._log.append(
-            (
-                "CP",
-                [control, target],
-                {"lambda": lam}
-            )
-        )
-
-        return self
+    
+    
 
     def _gate_toffoli(self, c0: int, c1: int, tgt: int) -> None:
         """Dispatch Toffoli to the active backend."""

--- a/2026-05-circuit-simulator/qcsim/qcsim/gates.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/gates.py
@@ -293,6 +293,16 @@ def CP_mat(lam: float) -> np.ndarray:
     ).astype(complex)
 
 def CCNOT_mat() -> np.ndarray:
+    """Toffoli (CCNOT) gate matrix.
+
+    Flips the target qubit when both control qubits are |1⟩.
+
+    Basis ordering:
+      |000⟩, |001⟩, |010⟩, |011⟩,
+       |100⟩, |101⟩, |110⟩, |111⟩
+    Returns:
+       8x8 complex array.
+   """
     mat = np.eye(8, dtype=complex)
 
     mat[6, 6] = 0
@@ -334,6 +344,7 @@ def CSWAP_mat() -> np.ndarray:
     mat[6, 5] = 1
 
     return mat
+
 
 # ================================================================== #
 #  Convenience: catalogue of all named single-qubit gates

--- a/2026-05-circuit-simulator/qcsim/qcsim/gates.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/gates.py
@@ -251,6 +251,57 @@ def CZ_mat() -> np.ndarray:
     """
     return np.diag([1.0, 1.0, 1.0, -1.0]).astype(complex)
 
+def CY_mat() -> np.ndarray:
+    """Controlled-Y gate matrix.
+
+    Applies Y to the target qubit when
+    the control qubit is |1>.
+
+    Basis ordering:
+        |00>, |01>, |10>, |11>
+
+    Returns:
+        4x4 complex array.
+    """
+    return np.array(
+        [
+            [1, 0, 0, 0],
+            [0, 1, 0, 0],
+            [0, 0, 0, -1j],
+            [0, 0, 1j, 0],
+        ],
+        dtype=complex,
+    )
+
+def CP_mat(lam: float) -> np.ndarray:
+    """Controlled phase gate.
+
+    Applies a phase e^(i·λ) to |11⟩.
+
+    Basis ordering:
+        |00>, |01>, |10>, |11>
+
+    Args:
+        lam:
+            Phase angle in radians.
+
+    Returns:
+        4x4 complex array.
+    """
+    return np.diag(
+        [1, 1, 1, np.exp(1j * lam)]
+    ).astype(complex)
+
+def CCNOT_mat() -> np.ndarray:
+    mat = np.eye(8, dtype=complex)
+
+    mat[6, 6] = 0
+    mat[7, 7] = 0
+
+    mat[6, 7] = 1
+    mat[7, 6] = 1
+
+    return mat
 
 def SWAP_mat() -> np.ndarray:
     """SWAP gate matrix. Exchanges two qubit states.
@@ -261,7 +312,28 @@ def SWAP_mat() -> np.ndarray:
     return np.array(
         [[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]], dtype=complex
     )
+def CSWAP_mat() -> np.ndarray:
+    """Fredkin (controlled-SWAP) gate.
 
+    Swaps the two target qubits when
+    the control qubit is |1>.
+
+    Basis ordering:
+        |000>, |001>, |010>, |011>,
+        |100>, |101>, |110>, |111>
+
+    Returns:
+        8x8 complex array.
+    """
+    mat = np.eye(8, dtype=complex)
+
+    mat[5, 5] = 0
+    mat[6, 6] = 0
+
+    mat[5, 6] = 1
+    mat[6, 5] = 1
+
+    return mat
 
 # ================================================================== #
 #  Convenience: catalogue of all named single-qubit gates


### PR DESCRIPTION
1. Duplicate cy() definition (circuit.py lines 360-377) — Critical
cy() is already defined at line 722 with better documentation. Python silently uses the later definition, so lines 360-377 are dead code. Remove them entirely.

Removed the definition

2. Duplicate cp() definition with wrong parameter key (circuit.py lines 378-399) — Critical
Same duplicate problem, but worse — line 395 logs the parameter as {"lambda": lam} while every downstream consumer (_replay_gate at line 1021, to_qiskit_code at line 1192, to_qasm2 at line 1349) reads p["lam"]. This would silently break export and replay. The correct definition already exists at line 782. Remove lines 378-399 entirely.


Removed the definition

3. Missing docstring on CCNOT_mat() (gates.py lines 295-304) — Minor
Every other gate function in the file has a docstring. Add one here to keep things consistent.

Added a detailed doc string