### PR TITLE
Add Y, Z, S, and T gate support to TUI

### DIFF
--- a/2026-05-circuit-simulator/qcsim/qcsim/tui.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/tui.py
@@ -131,6 +131,10 @@ def _input(prompt: str) -> str:
 _GATE_DISPLAY: Dict[str, str] = {
     "H":        "H",
     "X":        "X",
+    "Y":        "Y",   # Pauli-Y gate
+    "Z":        "Z",   # Pauli-Z gate
+    "S":        "S",   # Phase gate
+    "T":        "T",   # π/8 gate
     "SXdg":     "D",   # SX-dagger gate
     "CNOT_C":   "@",   # CNOT control  (@  looks like a control dot)
     "CNOT_T":   "+",   # CNOT target   (+ looks like XOR/circle-plus)
@@ -320,7 +324,7 @@ def _render_grid(
     lines.append("")
 
     # Help
-    lines.append("  Gates : [H] [X] [D] [C]NOT S[W]AP  |  [Backspace] delete")
+    lines.append("  Gates : [H] [X] [Y] [Z] [S] [T] [D] [C]NOT S[W]AP  |  [Backspace] delete")
     lines.append("  Help  : [?] gate info")
     lines.append("  Expand: [+] add column  [*] add qubit row")
     lines.append("  Action: [R]un  [E]xport JSON  [Ctrl+K] py/qasm  [I]mport  [Q]uit")
@@ -469,6 +473,14 @@ class CircuitBuilder:
             self._place_single("H")
         elif key == "x":
             self._place_single("X")
+        elif key == "y":
+            self._place_single("Y")
+        elif key == "z":
+            self._place_single("Z")
+        elif key == "s":
+            self._place_single("S")
+        elif key == "t":
+            self._place_single("T")
         elif key == "d":
             self._place_single("SXdg")
 

--- a/2026-05-circuit-simulator/qcsim/qcsim/tui.py
+++ b/2026-05-circuit-simulator/qcsim/qcsim/tui.py
@@ -635,6 +635,14 @@ class CircuitBuilder:
                     qc.h(row)
                 elif g == "X":
                     qc.x(row)
+                elif g == "Y":
+                    qc.y(row)
+                elif g == "Z":
+                    qc.z(row)
+                elif g == "S":
+                    qc.s(row)
+                elif g == "T":
+                    qc.t(row)
                 elif g == "SXdg":
                     qc.sxdg(row)
                 elif g == "CNOT_C":
@@ -683,6 +691,42 @@ class CircuitBuilder:
                 "X*X = Identity",
                 "",
                 "Use: Initialise qubits to |1>, flip bits, build CNOT.",
+            ),
+            "Y": (
+                "Pauli-Y Gate",
+                "Matrix: [[0, -i], [i, 0]]",
+                "Y|0> = i|1>",
+                "Y|1> = -i|0>",
+                "Y*Y = Identity",
+                "",
+                "Use: Bit flip + phase flip. Useful in rotations and error correction.",
+            ),
+            "Z": (
+                "Pauli-Z Gate",
+                "Matrix: [[1, 0], [0, -1]]",
+                "Z|0> = |0>",
+                "Z|1> = -|1>",
+                "Z*Z = Identity",
+                "",
+                "Use: Phase flip. Fundamental for phase-based quantum algorithms.",
+            ),
+            "S": (
+                "S Gate (Phase Gate)",
+                "Matrix: [[1, 0], [0, i]]",
+                "S|0> = |0>",
+                "S|1> = i|1>",
+                "S*S = Z",
+                "",
+                "Use: Applies a 90° phase rotation to |1>.",
+            ),
+            "T": (
+                "T Gate (π/8 Gate)",
+                "Matrix: [[1, 0], [0, exp(iπ/4)]]",
+                "T|0> = |0>",
+                "T|1> = exp(iπ/4)|1>",
+                "T*T = S",
+                "",
+                "Use: Fundamental non-Clifford gate for universal quantum computing.",
             ),
             "SXdg": (
                 "SX-dagger Gate",
@@ -738,6 +782,10 @@ class CircuitBuilder:
                 "Place a gate here:",
                 "  [H]  Hadamard          creates superposition",
                 "  [X]  Pauli-X           flips the qubit (NOT gate)",
+                "  [Y]  Pauli-Y           bit + phase flip",
+                "  [Z]  Pauli-Z           phase flip",
+                "  [S]  Phase gate        90° phase rotation",
+                "  [T]  π/8 gate          universal QC building block",
                 "  [C]  CNOT              controlled-NOT (two-qubit entanglement)",
                 "  [W]  SWAP              exchange two qubit states",
                 "",


### PR DESCRIPTION
## What does this PR do?

Adds Y, Z, S, and T gate support to the interactive TUI circuit builder by adding keyboard shortcuts, gate display symbols, and updating the help text.

## Type of change

* [ ] 🐛 Bug fix (challenge files, README, tests)
* [ ] ✨ New gate (adds gate to qcsim)
* [ ] 📚 New circuit (adds circuit to circuit-library)
* [ ] 📝 Documentation improvement
* [x] 🔧 CI / tooling

---

## For bug fixes / docs

* [x] Change is minimal and targeted
* [x] No solution code added to main repo (solutions go in Discussions)
* [x] Tested locally

---

## Notes for reviewer

The simulator already supports Y, Z, S, and T gates internally. This PR exposes them in the interactive TUI by:

* Adding display symbols for Y, Z, S, and T gates
* Adding keyboard shortcuts (`y`, `z`, `s`, `t`)
* Updating the help text to show the new shortcuts

Tested manually using `qcsim-interactive` and verified that the existing test suite passes (`77 passed, 1 skipped`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for single-qubit gate types Y, Z, S, and T in the terminal interface
  * Gates can now be placed using keyboard shortcuts (y, z, s, t)
  * Updated help/legend to reflect new gate options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->