### PR TITLE
test(qft): add QFT and IQFT correctness tests

### DIFF
--- a/2026-05-circuit-simulator/qcsim/tests/test_circuit.py
+++ b/2026-05-circuit-simulator/qcsim/tests/test_circuit.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from qcsim import QuantumCircuit
+from qcsim import QuantumCircuit, qft, inverse_qft
 from qcsim.exceptions import QubitIndexError
 
 
@@ -497,6 +497,33 @@ class TestAlgorithms:
         # After 1 Grover iteration on 2 qubits, |11⟩ should dominate
         assert probs.get("11", 0) > 0.95
 
+    def test_qft_iqft_recovers_basis_state(self):
+        """QFT followed by IQFT should recover |101⟩."""
+        qc = QuantumCircuit(3)
+
+        qc.x(0)
+        qc.x(2)
+
+        original = qc.statevector().copy()
+
+        qft(qc, [0, 1, 2])
+        inverse_qft(qc, [0, 1, 2])
+
+        assert np.allclose(original, qc.statevector())
+
+    def test_qft_iqft_recovers_superposition(self):
+        """QFT followed by IQFT should recover a superposition state."""
+        qc = QuantumCircuit(3)
+
+        qc.h(0)
+        qc.h(1)
+
+        original = qc.statevector().copy()
+
+        qft(qc, [0, 1, 2])
+        inverse_qft(qc, [0, 1, 2])
+
+        assert np.allclose(original, qc.statevector())
 
 # ================================================================== #
 #  Qiskit export


### PR DESCRIPTION
## What does this PR do?

Adds automated correctness tests for the reusable Quantum Fourier Transform (QFT) implementation.

### Added tests

* Verify that QFT followed by IQFT recovers the original computational basis state `|101⟩`
* Verify that QFT followed by IQFT recovers a superposition state

These tests provide regression coverage for the reusable QFT/IQFT subroutines and help ensure correctness under future changes.

## Validation

* `pytest` → 79 passed, 1 skipped
* All existing tests continue to pass

## Notes for reviewer

The tests use the public `qft` and `inverse_qft` API exported by `qcsim` and follow the existing testing style used throughout `test_circuit.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test cases for quantum Fourier transform operations.
  * Verified that applying QFT followed by inverse QFT correctly restores both computational basis states and quantum superposition states to their original values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->